### PR TITLE
Fix/django version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,19 @@ python -c 'from django.core.management.utils import get_random_secret_key; print
 git clone https://github.com/lukuku-dev/django-rest-boilerplate.git
 # Change directory
 cd django-rest-boilerplate
+# See available pyton versions
+pyenv install --list
+# Install the python version
+pyenv install 3.9.13
 # Create a virtual environment
+pyenv virtualenv 3.9.13 <env-name>
+# Activate the virtual environment
+pyenv activate <env-name>
 # Please use pyenv here, if you want to attach this code with aws-lambda
 # Install the requirements
 pip install -r requirements.txt
 # rename .env.example to .env
 # Fill the variables
-
 # Run the migrations
 python manage.py migrate
 # Create a superuser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.1.1
+Django==4.0.5
 zappa==0.55.0
 django-storages==1.12.3
 django-model-utils==4.2.0
@@ -11,3 +11,4 @@ djangorestframework==3.13.1
 djangorestframework-camel-case==1.3.0
 drf-spectacular==0.22.1
 django-extensions==3.1.5
+django-environ==0.8.1


### PR DESCRIPTION
 The New Django version is not supported by PostgreSQL


**Regenerate The Error**
Versions
```
Python 3.9.13
Django-4.1.1
psycopg2-binary==2.9.5
```


Got this error
```
    raise NotSupportedError(
Django.db.utils.NotSupportedError: PostgreSQL 11 or later is required (found 10.22).
```


Solved Error by Rolling back to old version
```
Django-4.0.5
```